### PR TITLE
feature: add entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,23 +73,28 @@ Each step is elaborted in details in **guideline** folder.
 
 To get a local copy up and running follow these simple steps.
 
-1. Clone the repo
+1. Clone the repo:
 ```sh
 git clone https://github.com/github_username/tweet_collector.git
 ```
-2. Install the package dependencies
-   1. If you have poetry 
-    ```sh
-    poetry install 
-    ```
-   2. If you have only pip
-   ```sh
-   pip install -r requirement.txt
-   ```
+1. (Optional but recommended) Create and activate a virtual environment
+1. Create package file:
+```
+poetry package
+```
+1. Install package through pip:
+```
+pip install ./dist/tweet_collector_version.whl
+```
 
 <!-- USAGE -->
 ## Usage
+If the installation through pip was followed:
+1. Make sure you are inside the virtual environment tweet_collector was installed in
+1. Run the `tweet_collector` command to start collecting the tweets
+1. Run the `tweet_collector_elastic` command to visualise the results in Kibana.
 
+Alternatively, you can launch the files directly through the supplies shell scripts:
 - To collect the tweets of your interest, you will make use of the file `sh search_tweet.sh`.
 Go to 'guidelines/Search_Tweets.ipynb' for more details.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ git clone https://github.com/github_username/tweet_collector.git
 1. (Optional but recommended) Create and activate a virtual environment
 1. Create package file:
 ```
-poetry package
+poetry build
 ```
 1. Install package through pip:
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,6 @@ ipykernel = "^6.4.1"
 pytest = "^5.2"
 autopep8 = "^1.5.7"
 
-[tool.poetry.scripts]
-tweet-collector="src.search_tweet:main"
-tweet-collector-elastic="src.load_elastic:main"
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ ipykernel = "^6.4.1"
 pytest = "^5.2"
 autopep8 = "^1.5.7"
 
+[tool.poetry.scripts]
+tweet-collector="src.search_tweet:main"
+tweet-collector-elastic="src.load_elastic:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ pytest = "^5.2"
 autopep8 = "^1.5.7"
 
 [tool.poetry.scripts]
-tweet-collector="src.search_tweet:main"
-tweet-collector-elastic="src.load_elastic:main"
+tweet_collector="src.search_tweet:main"
+tweet_collector_elastic="src.load_elastic:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ pytest = "^5.2"
 autopep8 = "^1.5.7"
 
 [tool.poetry.scripts]
-tweet-collector="tweet_collector.search_tweet:main"
-tweet-collector-elastic="tweet_collector.load_elastic:main"
+tweet-collector="src.search_tweet:main"
+tweet-collector-elastic="src.load_elastic:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ ipykernel = "^6.4.1"
 pytest = "^5.2"
 autopep8 = "^1.5.7"
 
+[tool.poetry.scripts]
+tweet-collector="tweet_collector.search_tweet:main"
+tweet-collector-elastic="tweet_collector.load_elastic:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
With these entrypoints, when `poetry build` is ran, the created .whl in the dist/ directory can be installed with pip and creates the commands to launch the tweet_collector from the terminal directly, without using the bash script files.